### PR TITLE
cleanup levenshtein and fix cpplint warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,6 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
 endif()
 
 
-# Find Catch
-# ------------------------
-FIND_PATH(CATCH_INCLUDE_PATH
-    catch.hpp
-    PATHS
-        ${CMAKE_SOURCE_DIR}/test
-)
-
 # Executable
 # ------------------------
 FILE(GLOB SOURCE_FILES src/*.cc src/modules/*.cc)
@@ -60,11 +52,7 @@ add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
 # Build tests if CMAKE_BUILD_TYPE=Debug is set
 # ------------------------
 if (CMAKE_BUILD_TYPE MATCHES DEBUG OR CMAKE_BUILD_TYPE MATCHES "Debug")
-    if (NOT CATCH_INCLUDE_PATH)
-        MESSAGE(SEND_ERROR "Could not find file catch.hpp")
-    else()
-        include_directories(${CATCH_INCLUDE_PATH})
-        FILE(GLOB TEST_FILES test/*.cc test/modules/*.cc)
-        add_executable("${PROJECT_NAME}-test" ${TEST_FILES})
-    endif()
+    include_directories(${CATCH_INCLUDE_PATH})
+    FILE(GLOB TEST_FILES test/*.cc test/modules/*.cc)
+    add_executable("${PROJECT_NAME}-test" ${TEST_FILES})
 endif()

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -26,8 +26,8 @@
 #include "../utils.h"
 
 bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
-  std::string str1 = seq1->seq();
-  std::string str2 = seq2->seq();
+  const std::string& str1 = seq1->seq();
+  const std::string& str2 = seq2->seq();
 
   // return true if the two strings are the same
   if (&str1 == &str2) return true;

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -30,8 +30,11 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   const std::string& str1 = seq1->seq();
   const std::string& str2 = seq2->seq();
 
-  // return true if the two strings are the same
+  // degenerate cases
+  // Return true if the two strings are the same
   if (&str1 == &str2) return true;
+  // If any of the string are empty they are always 100% different. Return false
+  if (str1.empty() || str2.empty()) return false;
 
   // Get data for calculating relative distance.
   size_t lengthDiff = (str1.length() < str2.length()
@@ -40,16 +43,9 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   size_t smallestLength = (str1.length() < str2.length()
         ? str1.length()
         : str2.length());
+        
   // Maximal errors before fail-fast kicks in
   float maxErrors = getIdentity() * smallestLength + lengthDiff;
-
-  // degenerate cases
-  if (str1.length() == 0 && maxErrors < str2.length()) {
-    return false;
-  }
-  if (str2.length() == 0 && maxErrors < str1.length()) {
-    return false;
-  }
 
   // create two work arrays of integer distances
   std::unique_ptr<size_t[]> v0(new size_t[str2.length() + 1]);

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -20,6 +20,8 @@
 
 #include "levenshtein.h"
 
+#include <cctype>
+
 #include "../seq_entry.h"
 #include "../utils.h"
 

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -47,8 +47,16 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   float maxErrors = getIdentity() * smallestLength + lengthDiff;
 
   // degenerate cases
-  if (str1.length() == 0 && maxErrors < str2.length()) return false;
-  if (str2.length() == 0 && maxErrors < str1.length()) return false;
+  if (str1.length() == 0 && maxErrors < str2.length()) {
+    delete[] v0;
+    delete[] v1;
+    return false;
+  }
+  if (str2.length() == 0 && maxErrors < str1.length()) {
+    delete[] v0;
+    delete[] v1;
+    return false;
+  }
 
   // initialize v0 (the previous row of distances)
   // this row is A[0][i]: edit distance for an empty str1

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -29,14 +29,12 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   std::string str1 = seq1->seq();
   std::string str2 = seq2->seq();
 
-  // degenerate cases
-  if (&str1 == &str2) return 0.0f;
-  if (str1.length() == 0) return str2.length();
-  if (str2.length() == 0) return str1.length();
+  // return true if the two strings are the same
+  if (&str1 == &str2) return true;
 
   // create two work vectors of integer distances
-  int* v0 = new int[str2.length() + 1];
-  int* v1 = new int[str2.length() + 1];
+  size_t* v0 = new size_t[str2.length() + 1];
+  size_t* v1 = new size_t[str2.length() + 1];
 
   // Get data for calculating relative distance.
   size_t lengthDiff = (str1.length() < str2.length()
@@ -47,6 +45,10 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
         : str2.length());
   // Maximal errors before fail-fast kicks in
   float maxErrors = getIdentity() * smallestLength + lengthDiff;
+
+  // degenerate cases
+  if (str1.length() == 0 && maxErrors < str2.length()) return false;
+  if (str2.length() == 0 && maxErrors < str1.length()) return false;
 
   // initialize v0 (the previous row of distances)
   // this row is A[0][i]: edit distance for an empty str1
@@ -61,7 +63,7 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
     // first element of v1 is A[i+1][0]
     //   edit distance is delete (i+1) chars from s to match empty t
     v1[0] = i + 1;
-    int minErrors = v1[0];
+    size_t minErrors = v1[0];
 
     // use formula to fill in the rest of the row
     for (size_t j = 0; j < str2.length(); j++) {
@@ -79,16 +81,16 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
     }
 
     // Swap pointer v0 and v1
-    int* tmp = v0;
+    size_t* tmp = v0;
     v0 = v1;
     v1 = tmp;
   }
 
-  int result = v0[str2.length()];
+  size_t result = v0[str2.length()];
 
   delete[] v0;
   delete[] v1;
 
   float similarity = static_cast<float>((result - lengthDiff)) / smallestLength;
-  return similarity < getIdentity(); 
+  return similarity < getIdentity();
 }

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -21,8 +21,7 @@
 #include "levenshtein.h"
 
 #include "../seq_entry.h"
-
-#define MIN3(a, b, c) ((a) < (b) ? ((a) < (c) ? (a) : (c)) : ((b) < (c) ? (b) : (c)))
+#include "../utils.h"
 
 bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   std::string str1 = seq1->seq();
@@ -38,22 +37,23 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   int* v1 = new int[str2.length() + 1];
 
   // Get data for calculating relative distance.
-  int lengthDiff = (int) (str1.length() < str2.length()
-                          ? str2.length() - str1.length()
-                          : str1.length() - str2.length());
-  int smallestLength = (int) (str1.length() < str2.length() ? str1.length() : str2.length());
+  size_t lengthDiff = (str1.length() < str2.length()
+        ? str2.length() - str1.length()
+        : str1.length() - str2.length());
+  size_t smallestLength = (str1.length() < str2.length()
+        ? str1.length()
+        : str2.length());
   // Maximal errors before fail-fast kicks in
   float maxErrors = getIdentity() * smallestLength + lengthDiff;
 
   // initialize v0 (the previous row of distances)
   // this row is A[0][i]: edit distance for an empty str1
   // the distance is just the number of characters to delete from str2
-  for (int i = 0; i < (int)str2.length() + 1; i++) {
+  for (size_t i = 0; i < str2.length() + 1; i++) {
     v0[i] = i;
   }
 
-  for (int i = 0; i < (int)str1.length(); i++)
-  {
+  for (size_t i = 0; i < str1.length(); i++) {
     // calculate v1 (current row distances) from the previous row v0
 
     // first element of v1 is A[i+1][0]
@@ -62,10 +62,9 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
     int minErrors = v1[0];
 
     // use formula to fill in the rest of the row
-    for (int j = 0; j < (int)str2.length(); j++)
-    {
-      int cost = ((str1[i]|32) == (str2[j]|32)) ? 0 : 1;
-      v1[j + 1] = MIN3(v1[j] + 1, v0[j + 1] + 1, v0[j] + cost);
+    for (size_t j = 0; j < str2.length(); j++) {
+      int cost = (tolower(str1[i]) == tolower(str2[j])) ? 0 : 1;
+      v1[j + 1] = min3(v1[j] + 1, v0[j + 1] + 1, v0[j] + cost);
       if (v1[j + 1] < minErrors)
         minErrors = v1[j + 1];
     }
@@ -88,5 +87,6 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   delete[] v0;
   delete[] v1;
 
-  return ((float)(result - lengthDiff) / smallestLength) < getIdentity();
+  float similarity = static_cast<float>((result - lengthDiff)) / smallestLength;
+  return similarity < getIdentity(); 
 }

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -32,10 +32,6 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
   // return true if the two strings are the same
   if (&str1 == &str2) return true;
 
-  // create two work vectors of integer distances
-  size_t* v0 = new size_t[str2.length() + 1];
-  size_t* v1 = new size_t[str2.length() + 1];
-
   // Get data for calculating relative distance.
   size_t lengthDiff = (str1.length() < str2.length()
         ? str2.length() - str1.length()
@@ -48,15 +44,15 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
 
   // degenerate cases
   if (str1.length() == 0 && maxErrors < str2.length()) {
-    delete[] v0;
-    delete[] v1;
     return false;
   }
   if (str2.length() == 0 && maxErrors < str1.length()) {
-    delete[] v0;
-    delete[] v1;
     return false;
   }
+
+  // create two work vectors of integer distances
+  size_t* v0 = new size_t[str2.length() + 1];
+  size_t* v1 = new size_t[str2.length() + 1];
 
   // initialize v0 (the previous row of distances)
   // this row is A[0][i]: edit distance for an empty str1

--- a/src/modules/levenshtein.cc
+++ b/src/modules/levenshtein.cc
@@ -21,6 +21,7 @@
 #include "levenshtein.h"
 
 #include <cctype>
+#include <memory>
 
 #include "../seq_entry.h"
 #include "../utils.h"
@@ -50,9 +51,9 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
     return false;
   }
 
-  // create two work vectors of integer distances
-  size_t* v0 = new size_t[str2.length() + 1];
-  size_t* v1 = new size_t[str2.length() + 1];
+  // create two work arrays of integer distances
+  std::unique_ptr<size_t[]> v0(new size_t[str2.length() + 1]);
+  std::unique_ptr<size_t[]> v1(new size_t[str2.length() + 1]);
 
   // initialize v0 (the previous row of distances)
   // this row is A[0][i]: edit distance for an empty str1
@@ -78,22 +79,15 @@ bool LevenshteinDistance::compare(SeqEntry* seq1, SeqEntry* seq2) {
     }
 
     if (minErrors > maxErrors) {
-      delete[] v0;
-      delete[] v1;
       // Fail Fast
       return false;
     }
 
     // Swap pointer v0 and v1
-    size_t* tmp = v0;
-    v0 = v1;
-    v1 = tmp;
+    v0.swap(v1);
   }
 
   size_t result = v0[str2.length()];
-
-  delete[] v0;
-  delete[] v1;
 
   float similarity = static_cast<float>((result - lengthDiff)) / smallestLength;
   return similarity < getIdentity();

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,17 +18,18 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#ifndef KLUST_MODULES_LEVENSHTEIN_H_
-#define KLUST_MODULES_LEVENSHTEIN_H_
+#ifndef KLUST_UTILS_H_
+#define KLUST_UTILS_H_
 
-#include <string>
+template<typename T>
+inline T const& min3 (T const& a, T const& b, T const& c){
+    return a < b
+        ? (a < c
+            ? a
+            : c)
+        : (b < c ?
+            b
+            : c);
+}
 
-#include "../seq_entry.h"
-#include "../interface_compare.h"
-
-class LevenshteinDistance : public InterfaceCompare {
- public:
-  bool compare(SeqEntry* seq1, SeqEntry* seq2);
-};
-
-#endif  // KLUST_MODULES_LEVENSHTEIN_H_
+#endif // KLUST_FASTA_READER_H_

--- a/test/modules/test_kmer_gen.cc
+++ b/test/modules/test_kmer_gen.cc
@@ -18,6 +18,6 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <catch.hpp>
+#include "../catch.hpp"
 
 #include "../../src/modules/kmer_gen.cc"

--- a/test/modules/test_levenshtein.cc
+++ b/test/modules/test_levenshtein.cc
@@ -41,4 +41,62 @@ TEST_CASE("Levenshtein returns a correct result after comparison", "[levenshtein
 
     REQUIRE(compare.compare(&t1, &t2) == false);
   }
+
+  SECTION("compare two similar strings of differing length") {
+    t1.set_seq("acgtagcgcggctatagcgcataaatcgctctagcgctatcttcgggttagca");
+    t2.set_seq("acgtagcgcggctatagcgcataaatcctctagcgctatcttcgggttagca");
+
+    REQUIRE(compare.compare(&t1, &t2));
+  }
+
+  SECTION("compare two similar strings of same length") {
+    t1.set_seq("acgtagcgcggctatagcgcataaatcgctctagcgctatcttcgggttagca");
+    t2.set_seq("acgtagcgcggctatagcgcataaatcgctctagcgctatcttcgggttagca");
+
+    REQUIRE(compare.compare(&t1, &t2));
+  }
+}
+
+TEST_CASE("Levenshtein properly handles empty sequences", "[levenshtein]") {
+  SeqEntry t1, t2;
+  LevenshteinDistance compare;
+  compare.setIdentity(0.05f);
+
+  SECTION("First sequence is empty") {
+    t1.set_seq("");
+    t2.set_seq("a");
+
+    REQUIRE(!compare.compare(&t1, &t2));
+  }
+
+  SECTION("Second Sequence is empty") {
+    t1.set_seq("a");
+    t2.set_seq("");
+
+    REQUIRE(!compare.compare(&t1, &t2));
+  }
+}
+
+TEST_CASE("Levenshtein properly handles same sequence", "[levenshtein]") {
+  SeqEntry t1;
+  LevenshteinDistance compare;
+  t1.set_seq("acgt");
+
+  SECTION("identity is 0.05f") {
+    compare.setIdentity(0.05f);
+
+    REQUIRE(compare.compare(&t1, &t1));
+  }
+
+  SECTION("identity is 0.00f") {
+    compare.setIdentity(0.00f);
+
+    REQUIRE(compare.compare(&t1, &t1));
+  }
+
+  SECTION("identity is 1.00f") {
+    compare.setIdentity(1.00f);
+
+    REQUIRE(compare.compare(&t1, &t1));
+  }
 }

--- a/test/modules/test_levenshtein.cc
+++ b/test/modules/test_levenshtein.cc
@@ -18,7 +18,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <catch.hpp>
+#include "../catch.hpp"
 #include <string>
 
 #include "../../src/modules/levenshtein.cc"

--- a/test/modules/test_levenshtein.cc
+++ b/test/modules/test_levenshtein.cc
@@ -51,7 +51,7 @@ TEST_CASE("Levenshtein returns a correct result after comparison", "[levenshtein
 
   SECTION("compare two similar strings of same length") {
     t1.set_seq("acgtagcgcggctatagcgcataaatcgctctagcgctatcttcgggttagca");
-    t2.set_seq("acgtagcgcggctatagcgcataaatcgctctagcgctatcttcgggttagca");
+    t2.set_seq("acgtagcgcggctatagcgcataaatgggtctagcgctatcttcgggttagca");
 
     REQUIRE(compare.compare(&t1, &t2));
   }

--- a/test/test_kmer_collection.cc
+++ b/test/test_kmer_collection.cc
@@ -23,7 +23,7 @@
 #define G_ "11"
 #define T_ "10"
 
-#include <catch.hpp>
+#include "catch.hpp"
 
 #include "../src/kmer_collection.h"
 

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -19,4 +19,4 @@
  */
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include "catch.hpp"

--- a/test/test_seq_entry.cc
+++ b/test/test_seq_entry.cc
@@ -18,7 +18,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <catch.hpp>
+#include "catch.hpp"
 
 #include "../src/seq_entry.cc"
 


### PR DESCRIPTION
fixes #44 

Please let me know if there is anything more to be done.

Note that i deliberately did not split the function into sub-functions. I strongly agree with what @Chrikomu said at our meeting about not leaving the scope of a [`new`](https://github.com/BIO-DIKU/klust/compare/cleanup-levenshtein?expand=1#diff-f831fa14dc7a69883d32b1d8942e5298R36) until it has been [`delete`d](https://github.com/BIO-DIKU/klust/compare/cleanup-levenshtein?expand=1#diff-f831fa14dc7a69883d32b1d8942e5298R87) if possible. If you disagree i will be happy to pick up the discussion.
